### PR TITLE
[ZTP] Use config db instead of ZTP configuration profile

### DIFF
--- a/src/etc/default/ztp
+++ b/src/etc/default/ztp
@@ -18,3 +18,6 @@ COVERAGE=""
 # Change below to provide command coverage.py tool.
 # (python3-coverage run --append is used if not specified)
 COVERAGE_CMD=""
+
+# Use ZTP configuration profile (default) or config_db
+USE_DEFAULT_CONFIG="yes"

--- a/src/usr/lib/ztp/sonic-ztp
+++ b/src/usr/lib/ztp/sonic-ztp
@@ -37,6 +37,10 @@ start()
     # Custom ztp_cfg.json file
     [ "${CONFIG_JSON}" != "" ] && CONFIG_JSON_ARGS="-C ${CONFIG_JSON}"
 
+    # Use ZTP configuration profile (default) or config_db
+    [ "${USE_DEFAULT_CONFIG}" = "no" ] && CONFIG_DB_ARGS="-o"
+
+
     if [ "${COVERAGE}" = "yes" ]; then
         if which python3-coverage > /dev/null; then
             [ "${COVERAGE_CMD}" = "" ] && COVERAGE_EXP="python3-coverage run --append"
@@ -49,7 +53,7 @@ start()
     fi
 
     # Kickstart ZTP service daemon
-    ${COVERAGE_EXP} ${ZTP_ENGINE} ${DEBUG_ARGS} ${TEST_ARGS} ${CONFIG_JSON_ARGS} &
+    ${COVERAGE_EXP} ${ZTP_ENGINE} ${DEBUG_ARGS} ${TEST_ARGS} ${CONFIG_JSON_ARGS} ${CONFIG_DB_ARGS}&
 
     ztp_engine_pid=$!
     wait "$ztp_engine_pid"


### PR DESCRIPTION
Why I did it
- ZTP can not be used on the breakout port
- During ZTP init processing, there is no breakout port information to link up the port.

How I did it
- Allow user to specify either ZTP config or current config_db for ZTP initialization.
- Requires PR (https://github.com/edge-core/sonic-buildimage/pull/397) for full functionality.

How I verified it
1. Modify etc/default/ztp to use USE_DEFAULT_CONFIG="no"
2. Config breakout for port and enable link up.
3. config save
4. 'ztp run' to start ZTP.
5. breakout port should be 'Link up detected' and ZTP should start to downloading provisioning data from the port.